### PR TITLE
Added include guards via pragma once

### DIFF
--- a/src/SparkFunMPL3115A2.h
+++ b/src/SparkFunMPL3115A2.h
@@ -18,6 +18,8 @@
 
 #include <Wire.h>
 
+#pragma once
+
 #define MPL3115A2_ADDRESS 0x60 // Unshifted 7-bit I2C address for sensor
 
 #define STATUS     0x00


### PR DESCRIPTION
I am working in a group and we noticed include guards were missing here. I added them via `#pragma once` and have confirmed this works on my local PC.
