### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,18 +12,18 @@ MPL3115A2	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin  KEYWORD2
-readAltitude  KEYWORD2
-readAltitudeFt  KEYWORD2
-readPressure  KEYWORD2
-readTemp  KEYWORD2
-readTempF  KEYWORD2
-setModeBarometer  KEYWORD2
-setModeAltimeter  KEYWORD2
-setModeStandby  KEYWORD2
-setModeActive  KEYWORD2
-setOversampleRate KEYWORD2
-enableEventFlags KEYWORD2
+begin	KEYWORD2
+readAltitude	KEYWORD2
+readAltitudeFt	KEYWORD2
+readPressure	KEYWORD2
+readTemp	KEYWORD2
+readTempF	KEYWORD2
+setModeBarometer	KEYWORD2
+setModeAltimeter	KEYWORD2
+setModeStandby	KEYWORD2
+setModeActive	KEYWORD2
+setOversampleRate	KEYWORD2
+enableEventFlags	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords